### PR TITLE
fix sytanx error

### DIFF
--- a/src/base32.cr
+++ b/src/base32.cr
@@ -94,7 +94,7 @@ module Base32
   end
 
   # Encode data as base32 with padding, or without if `pad` = false
-  def encode(data, pad = true : Bool) : String
+  def encode(data, pad : Bool = true) : String
     to_base32(data, pad, CHARS_STD)
   end
 
@@ -109,7 +109,7 @@ module Base32
   end
 
   # Encode data as base32hex with padding, or without if `pad` = false
-  def hex_encode(data, pad = true : Bool) : String
+  def hex_encode(data, pad : Bool = true ) : String
     to_base32(data, pad, CHARS_HEX)
   end
 


### PR DESCRIPTION
https://github.com/crystal-lang/crystal/releases/tag/0.14.1

> 0.14.0 (2016-03-21)
> (breaking change) The syntax of a method argument with a default value and a type restriction is now def foo(arg : Type = default_value). Run crystal tool format to automatically upgrade exsiting code to this new syntax. The old def foo(arg = default_value : Type) was removed.
